### PR TITLE
[#29] chore: migrate workflows to github-workflows and align configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+---
+name: Bug report
+description: File a structured bug report
+title: "fix: [Brief Description of Bug]"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 🧪 Structured Bug Report
+        Thank you for reporting a bug! Please fill out the form sections below.
+  - type: textarea
+    id: what
+    attributes:
+      label: "1. What"
+      description: Describe the bug and what went wrong. Include step-by-step reproduction steps if possible.
+      placeholder: "Describe the bug..."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: "2. Why"
+      description: Motivation and context (e.g. impact on users, environments affected).
+      placeholder: "Motivation and context..."
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: "3. Value"
+      description: Technical value of fixing this issue (e.g., error prevention, stabilizing builds).
+      placeholder: "Technical value of fixing this..."
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: "4. Acceptance Criteria"
+      description: Criteria that must be met to consider this issue complete.
+      value: |
+        - [ ] Bug is resolved and cannot be reproduced.
+        - [ ] Automated/manual tests pass.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Workflows Documentation
+    url: https://github.com/grzegorzfranus/github-workflows#readme
+    about: Read the official documentation and conventions before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+---
+name: Feature request
+description: Suggest an enhancement or new feature
+title: "feat: [Brief Description of Feature]"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 💡 Structured Feature Request
+        Have an idea for a new feature? Tell us about it below!
+  - type: textarea
+    id: what
+    attributes:
+      label: "1. What"
+      description: Describe the requested feature and the proposed solution.
+      placeholder: "Describe the feature..."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: "2. Why"
+      description: Motivation and context (e.g. why is this needed, what problem does it solve).
+      placeholder: "Motivation and context..."
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: "3. Value"
+      description: Business or technical value (e.g., improves developer efficiency, improves security).
+      placeholder: "Technical or business value..."
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: "4. Acceptance Criteria"
+      description: Criteria that must be met to consider this issue complete.
+      value: |
+        - [ ] Feature is implemented and verified.
+        - [ ] Documentation is updated in README.md.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,44 @@
+---
+name: Task
+description: Create a structured task issue
+title: "chore: [Brief Description of Task]"
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 📋 Structured Task
+        Define a generic maintenance task or chore.
+  - type: textarea
+    id: what
+    attributes:
+      label: "1. What"
+      description: Description of the task.
+      placeholder: "Describe the task..."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: "2. Why"
+      description: Motivation and context.
+      placeholder: "Motivation and context..."
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: "3. Value"
+      description: Business or technical value.
+      placeholder: "Technical or business value..."
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: "4. Acceptance Criteria"
+      description: Criteria that must be met to consider this issue complete.
+      value: |
+        - [ ] Criteria 1
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+## 1. ✨ What this PR does
+
+- Description of the changes.
+
+## 2. 🔍 Why
+
+- Explanation of the problem or motivation.
+
+## 3. 💡 Value
+
+- Business or technical value.
+
+## 4. ✅ Local Verification
+
+- Steps to verify the changes (commands, manual tests).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   # ================================================================
   ci:
     needs: [branch-name-lint, pr-title-lint]
-    uses: grzegorzfranus/github-actions-workflows/.github/workflows/ansible-ci.yml@main
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-ci.yml@main
     with:
       molecule-distros: '["ubuntu2604", "ubuntu2404", "ubuntu2204", "debian13", "debian12", "debian11", "rockylinux9"]'
 
@@ -152,7 +152,7 @@ jobs:
   # one. This implements the two-tier gate pattern.
   # ================================================================
   merge-check:
-    name: "Merge Check"
+    name: "Merge Check Gate"
     needs: [branch-name-lint, pr-title-lint, ci]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,9 @@ permissions:
   statuses: write
 
 jobs:
-  # ================================================================
-  # 1. RELEASE PLEASE
-  # ----------------------------------------------------------------
-  # Analyzes Conventional Commits since last release and creates
-  # or updates a Release PR. When the Release PR is merged, it
-  # creates a Git tag and GitHub Release automatically.
-  # Note: Commits must follow the Conventional Commits specification.
-  # ================================================================
+  # Analyze Conventional Commits to manage release PR, Git tags, and GitHub releases
   release-please:
-    name: "Release Please"
+    name: "Run Release Please"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -28,20 +21,13 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: "Run Release Please"
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # ================================================================
-  # 2. VALIDATE RELEASE PR
-  # ----------------------------------------------------------------
-  # Runs basic validation on the Release PR branch and sets the
-  # required "Merge Check" commit status via the GitHub API.
-  # This is needed because PRs created by GITHUB_TOKEN do not
-  # trigger pull_request events in other workflows.
-  # ================================================================
+  # Validate Release PR branch and set "Merge Check" status via GitHub API
   validate-release-pr:
     name: "Validate Release PR"
     needs: [release-please]
@@ -49,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: "Get Release PR details"
+      - name: "Retrieve Release PR Details"
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,15 +53,15 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: "Checkout Release PR branch"
-        uses: actions/checkout@v6
+      - name: "Checkout Release PR Branch"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: release-please--branches--main
 
       - name: "Install yamllint"
         run: pip install yamllint
 
-      - name: "Lint YAML files"
+      - name: "Validate YAML Syntax"
         run: yamllint .
 
       - name: "Validate Galaxy metadata (meta/main.yml)"
@@ -105,31 +91,22 @@ jobs:
           print('Galaxy metadata validation passed')
           "
 
-      - name: "Set Merge Check status on PR"
+      - name: "Publish Merge Check Status"
         env:
           GH_TOKEN: ${{ github.token }}
           PR_SHA: ${{ steps.pr.outputs.sha }}
         run: |
           gh api "repos/${{ github.repository }}/statuses/$PR_SHA" \
             -f state=success \
-            -f context="Merge Check" \
+            -f context="Merge Check Gate" \
             -f description="All validations passed (Release PR)"
           echo "Set 'Merge Check' status on commit $PR_SHA"
 
-  # ================================================================
-  # 3. PUBLISH TO ANSIBLE GALAXY
-  # ----------------------------------------------------------------
-  # Triggered only when Release Please creates a GitHub Release
-  # (i.e., when the Release PR is merged). Uses the centralized
-  # reusable publish workflow with retry logic.
-  #
-  # This job lives here (not in a separate publish.yml) because
-  # events emitted by GITHUB_TOKEN do not trigger other workflows.
-  # ================================================================
+  # Publish role to Ansible Galaxy on release creation
   publish-to-galaxy:
     name: "Publish to Galaxy"
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
-    uses: grzegorzfranus/github-actions-workflows/.github/workflows/ansible-publish-galaxy.yml@main
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-publish.yml@main
     secrets:
       galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,53 @@
-# ignore visual studio code things, and intelliJ
-.vscode
-.idea
-.cursor
+# Development environment configuration
+.vscode/
+.idea/
+.cursor/
 
-# ignore Python Environments
+# Python virtual environment directories
 .env
-.venv
+.venv/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
 
-# ignore cache
-.cache
+# Python cache and compiled files
+__pycache__/
+*.py[cod]
+*$py.class
 
-# ignore Mac
+# Python tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+htmlcov/
+
+# Build and packaging artifacts
+build/
+dist/
+*.egg-info/
+
+# Cache files and directories
+.cache/
+
+# Ansible local artifacts and cache
+.ansible/
+retry_files_enabled
+*.retry
+
+# Log files
+*.log
+
+# Operating system generated files (macOS)
 .DS_Store
 
-# Asible
-.ansible/
+# Operating system generated files (Windows)
+Thumbs.db
+
+# Local environment variables and secrets
+.env.local
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -391,6 +391,18 @@ sudo logrotate -d /etc/logrotate.d/chrony
 
 ```
 ansible-role-chrony/
+├── .github/
+│   ├── ISSUE_TEMPLATE/                # Issue templates for bug, feature, task
+│   │   ├── bug_report.yml
+│   │   ├── config.yml
+│   │   ├── feature_request.yml
+│   │   └── task.yml
+│   ├── PULL_REQUEST_TEMPLATE/         # Pull request description template
+│   │   └── pull_request_template.md
+│   ├── workflows/
+│   │   ├── ci.yml                     # CI pipeline
+│   │   └── release.yml                # Release Please + Galaxy publish
+│   └── dependabot.yml                 # Dependabot configuration for GitHub Actions
 ├── defaults/
 │   └── main.yml             # Default configuration variables
 ├── handlers/
@@ -465,7 +477,8 @@ Contributions, bug reports, and feature requests are welcome!
 - Fork the repository and create your branch from `main`
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
 - Ensure your code passes all CI checks (YAML lint, Ansible lint, Molecule tests)
-- Submit a pull request describing your changes
+- Submit a pull request describing your changes (a template is available under `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` to help structure your PR description)
+- For major changes, please open an issue first to discuss what you would like to change (issue templates for bug reports, feature requests, and tasks are available under `.github/ISSUE_TEMPLATE/`)
 
 ## 📝 License
 


### PR DESCRIPTION
## 1. ✨ What this PR does

- Copies issue templates, pull request description template, and dependabot configuration from central workflows into the `.github/` folder.
- Replaces deprecated reusable workflow target `github-actions-workflows` with `github-workflows` in `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
- Aligns the `.gitignore` pattern with default development standards for Ansible roles.
- Updates the file structure diagram and contribution guidelines in `README.md` to reference the newly introduced templates.

## 2. 🔍 Why

- Standardizes CI/CD pipelines across roles.
- Switches the repository from referencing the old workflows repository (`github-actions-workflows`) to the new central workflows repository (`github-workflows`).
- Ensures dependabot and issue/PR templates are present for consistent metadata management.

## 3. 💡 Value

- Consistent and standardized CI/CD pipelines.
- Reduced manual template and workflow sync efforts.
- Improved code quality checks and easier contribution flow.

## 4. ✅ Local Verification

- Local syntactic validation was completed successfully:
  - `yamllint .` passed cleanly.
  - `ansible-lint .` passed with 0 failures and 0 warnings.

Closes #29
