### PR TITLE
ci(34): upgrade github workflows to v3.0.1 and update documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Warsaw"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      # Prefix configured to 'build' for action dependency updates
+      prefix: "build"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   # ================================================================
   ci:
     needs: [branch-name-lint, pr-title-lint]
-    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-ci.yml@main
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-ci.yml@v3.0.1
     with:
       molecule-distros: '["ubuntu2604", "ubuntu2404", "ubuntu2204", "debian13", "debian12", "debian11", "rockylinux9"]'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,6 @@ jobs:
     name: "Publish to Galaxy"
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
-    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-publish.yml@main
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-publish.yml@v3.0.1
     secrets:
       galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Contributions, bug reports, and feature requests are welcome!
 
 - Fork the repository and create your branch from `main`
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+- Centralized workflows from [github-workflows](https://github.com/grzegorzfranus/github-workflows) version `v3.0.1` are used to run CI/CD pipelines
 - Ensure your code passes all CI checks (YAML lint, Ansible lint, Molecule tests)
 - Submit a pull request describing your changes (a template is available under `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` to help structure your PR description)
 - For major changes, please open an issue first to discuss what you would like to change (issue templates for bug reports, feature requests, and tasks are available under `.github/ISSUE_TEMPLATE/`)


### PR DESCRIPTION
Closes #34

## 1. ✨ What this PR does

This PR updates the CI/CD workflows of `ansible-role-chrony` to reference version `v3.0.1` of the centralized workflows repository `grzegorzfranus/github-workflows`.
Specifically, it:
- Pins `.github/workflows/ci.yml` and `.github/workflows/release.yml` to the latest release tag (`@v3.0.1`).
- Aligns `.github/dependabot.yml` with the central repository policies (weekly Monday schedule, Warsaw timezone, 10 PR limit, minor/patch grouping, 14-day cooldown).
- Updates the `Contributing` section of `README.md` to reference the central workflow version.

## 2. 🔍 Why

This ensures the repository utilizes the latest secure, optimized, and standardized workflows instead of mutable `@main` branch references.

## 3. 💡 Value

Increases security, stability, and maintainability of the repository CI/CD pipeline, and ensures standard corporate dependency policies are enforced.

## 4. ✅ Local Verification

Local checks successfully executed and verified:
- `yamllint .github/workflows/*.yml`
- `actionlint`
