### PR TITLE
chore: align lint and repository configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,9 +1,7 @@
 ---
+profile: shared
 skip_list:
   - role-name
-
-profile: shared
-
 exclude_paths:
   - molecule/**
   - .github/workflows/**

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,5 @@
 ---
-profile: shared
+profile: production
 skip_list:
   - role-name
 exclude_paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: "CI"
 run-name: "CI: ${{ github.event.pull_request.title || github.ref_name }} by @${{ github.actor }}"
 
 on:
-  pull_request:
+  pull_request: {}
+
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ run-name: "CI: ${{ github.event.pull_request.title || github.ref_name }} by @${{
 on:
   pull_request: {}
 
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: "📝 Run Release Please"
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         id: release
         with:
           config-file: release-please-config.json
@@ -73,7 +73,7 @@ jobs:
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
 
       - name: "🔍 Checkout Release PR Branch"
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           ref: release-please--branches--main
           persist-credentials: false
@@ -82,7 +82,7 @@ jobs:
         run: pipx run yamllint .
 
       - name: "🔍 Validate GitHub Actions"
-        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7  # v2.2.0
 
       - name: "🔍 Validate Galaxy Metadata"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ Thumbs.db
 
 # Temporary working directory
 tmp/
-

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ Thumbs.db
 .env.local
 .env.*
 !.env.example
+
+# Temporary working directory
+tmp/
+

--- a/.yamllint
+++ b/.yamllint
@@ -1,26 +1,12 @@
 ---
 extends: default
-
 rules:
-  comments:
-    min-spaces-from-content: 1
-  comments-indentation: false
-  truthy:
-    allowed-values: ["true", "false", "yes", "no"]
   line-length:
     max: 200
     level: warning
-  braces:
-    min-spaces-inside: 0
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
   octal-values:
     forbid-implicit-octal: true
     forbid-explicit-octal: true
-
-ignore: |
-  .github/workflows/**
-  molecule/**
+  comments-indentation: false

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -56,16 +56,21 @@
           # -x avoids adjusting system clock (no CAP_SYS_TIME needed).
           ExecStart=
           ExecStart=/usr/sbin/chronyd -n -x $DAEMON_OPTS
-          # Clear security sandboxing that conflicts with container testing.
-          ProtectSystem=
-          ProtectHome=
-          PrivateTmp=
-          NoNewPrivileges=
-          ProtectKernelTunables=
-          ProtectControlGroups=
-          ProtectHostname=
-          ProtectKernelLogs=
-          ProtectKernelModules=
+          # Disable systemd sandboxing for container testing.
+          # NOTE: an empty assignment (e.g. "ProtectSystem=") only resets LIST-type directives.
+          # For boolean/enum directives systemd rejects it with "Invalid argument" and keeps the
+          # vendor unit value — which, combined with the cleared LogsDirectory= below, left
+          # /var/log read-only and crashed chronyd on startup (observed on ubuntu2604; other
+          # matrix distros were unaffected). Always use explicit "=no" here.
+          ProtectSystem=no
+          ProtectHome=no
+          PrivateTmp=no
+          NoNewPrivileges=no
+          ProtectKernelTunables=no
+          ProtectControlGroups=no
+          ProtectHostname=no
+          ProtectKernelLogs=no
+          ProtectKernelModules=no
           # Clear systemd-managed directories to prevent ownership conflicts.
           # With User= cleared, systemd would set these dirs to root:root,
           # conflicting with role's _chrony ownership.

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -51,6 +51,9 @@
           # Debian uses Type=notify, RHEL uses Type=forking — both conflict
           # with chronyd -n (foreground mode). Type=simple works universally.
           Type=simple
+          # Unset NOTIFY_SOCKET so chronyd 4.8+ doesn't attempt to send readiness notifications
+          # to an inactive systemd notification socket when Type=simple is used in containers.
+          UnsetEnvironment=NOTIFY_SOCKET
           # Run chronyd in foreground (-n) free-running mode (-x) inside Molecule
           # containers. -n keeps chronyd in foreground (matches Type=simple).
           # -x avoids adjusting system clock (no CAP_SYS_TIME needed).

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -51,8 +51,10 @@
           # Debian uses Type=notify, RHEL uses Type=forking — both conflict
           # with chronyd -n (foreground mode). Type=simple works universally.
           Type=simple
-          # Unset NOTIFY_SOCKET so chronyd 4.8+ doesn't attempt to send readiness notifications
-          # to an inactive systemd notification socket when Type=simple is used in containers.
+          # Unset NOTIFY_SOCKET as a defensive measure: with Type=simple systemd should not pass it,
+          # but chronyd attempts sd_notify whenever the variable is present in the environment.
+          # Observed on ubuntu2604: chronyd[1956]: Fatal error : Could not send notification to $NOTIFY_SOCKET.
+          # Harmless on distros where it is already unset.
           UnsetEnvironment=NOTIFY_SOCKET
           # Run chronyd in foreground (-n) free-running mode (-x) inside Molecule
           # containers. -n keeps chronyd in foreground (matches Type=simple).

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -132,11 +132,11 @@
     # ============================================================
     # Verification checks — non-failing data collection
     # ============================================================
-    - name: Verify | Check if chrony package is installed
-      ansible.builtin.package:
-        name: "{{ __chrony_package_name }}"
-        state: present
-      register: __verify_package_result
+    - name: Verify | Query installed chrony package
+      ansible.builtin.command: "{{ __chrony_binary_path }} --version"
+      register: __verify_package_version
+      changed_when: false
+      failed_when: false
 
     - name: Verify | Check if installed binary is available
       ansible.builtin.stat:
@@ -144,18 +144,17 @@
         checksum_algorithm: sha256
       register: __verify_binary_result
 
-    - name: Verify | Check if chrony service is running
-      ansible.builtin.service:
-        name: "{{ __chrony_service_name }}"
-        state: started
-      register: __verify_service_result
+    - name: Verify | Query chrony service active state
+      ansible.builtin.command: "systemctl is-active {{ __chrony_service_name }}"
+      register: __verify_service_active
+      changed_when: false
+      failed_when: false
 
-    - name: Verify | Check if chrony service is enabled
-      ansible.builtin.service:
-        name: "{{ __chrony_service_name }}"
-        state: started
-        enabled: true
-      register: __verify_service_enabled_result
+    - name: Verify | Query chrony service boot state
+      ansible.builtin.command: "systemctl is-enabled {{ __chrony_service_name }}"
+      register: __verify_service_enabled
+      changed_when: false
+      failed_when: false
 
     - name: Verify | Check if chrony configuration file exists
       ansible.builtin.stat:
@@ -163,29 +162,11 @@
         checksum_algorithm: sha256
       register: __verify_config_result
 
-    - name: Verify | Check chrony configuration file permissions
-      ansible.builtin.file:
-        path: "{{ __chrony_config_path }}"
-        state: file
-        owner: root
-        group: root
-        mode: "0644"
-      register: __verify_config_perms_result
-
     - name: Verify | Check if log directory exists
       ansible.builtin.stat:
         path: "{{ chrony_logdir_path }}"
         checksum_algorithm: sha256
       register: __verify_logdir_result
-
-    - name: Verify | Check log directory permissions
-      ansible.builtin.file:
-        path: "{{ chrony_logdir_path }}"
-        state: directory
-        owner: "{{ __chrony_log_directory_user }}"
-        group: "{{ __chrony_log_directory_user }}"
-        mode: "0750"
-      register: __verify_logdir_perms_result
 
     - name: Verify | Check if logrotate configuration exists
       ansible.builtin.stat:
@@ -210,12 +191,33 @@
     # ============================================================
     # Assertions
     # ============================================================
+    - name: Verify | Assert chrony package is installed
+      ansible.builtin.assert:
+        that:
+          - __verify_package_version.rc == 0
+        fail_msg: "Chrony is not installed — '{{ __chrony_binary_path }} --version' returned {{ __verify_package_version.rc }}"
+        success_msg: "Chrony package verified"
+
     - name: Verify | Assert Chrony binary exists
       ansible.builtin.assert:
         that:
           - __verify_binary_result.stat.exists
         fail_msg: "Chrony binary not found at {{ __chrony_binary_path }}"
         success_msg: "Chrony binary verified at {{ __chrony_binary_path }}"
+
+    - name: Verify | Assert chrony service is active
+      ansible.builtin.assert:
+        that:
+          - __verify_service_active.stdout | trim == 'active'
+        fail_msg: "Chrony service is not active (reported: {{ __verify_service_active.stdout | trim }})"
+        success_msg: "Chrony service is active"
+
+    - name: Verify | Assert chrony service is enabled on boot
+      ansible.builtin.assert:
+        that:
+          - __verify_service_enabled.stdout | trim == 'enabled'
+        fail_msg: "Chrony service is not enabled on boot (reported: {{ __verify_service_enabled.stdout | trim }})"
+        success_msg: "Chrony service is enabled on boot"
 
     - name: Verify | Assert configuration file exists
       ansible.builtin.assert:
@@ -224,14 +226,37 @@
         fail_msg: "Chrony configuration file not found at {{ __chrony_config_path }}"
         success_msg: "Chrony configuration file verified"
 
-    - name: Verify | Show verification results
-      ansible.builtin.debug:
-        msg: "All Chrony verification checks completed successfully"
+    - name: Verify | Assert configuration file ownership and mode
+      ansible.builtin.assert:
+        that:
+          - __verify_config_result.stat.pw_name == 'root'
+          - __verify_config_result.stat.gr_name == 'root'
+          - __verify_config_result.stat.mode == '0644'
+        fail_msg: >-
+          Wrong configuration file permissions:
+          {{ __verify_config_result.stat.pw_name }}:{{ __verify_config_result.stat.gr_name }}
+          {{ __verify_config_result.stat.mode }} (expected root:root 0644)
+        success_msg: "Configuration file permissions verified (root:root 0644)"
+
+    - name: Verify | Assert log directory ownership and mode
+      ansible.builtin.assert:
+        that:
+          - __verify_logdir_result.stat.isdir
+          - __verify_logdir_result.stat.pw_name == __chrony_log_directory_user
+          - __verify_logdir_result.stat.gr_name == __chrony_log_directory_user
+          - __verify_logdir_result.stat.mode == '0750'
+        fail_msg: >-
+          Wrong log directory permissions:
+          {{ __verify_logdir_result.stat.pw_name }}:{{ __verify_logdir_result.stat.gr_name }}
+          {{ __verify_logdir_result.stat.mode }}
+          (expected {{ __chrony_log_directory_user }}:{{ __chrony_log_directory_user }} 0750)
+        success_msg: "Log directory permissions verified"
+      when: chrony_log_enable | bool
 
     - name: Verify | Final verification summary
       ansible.builtin.debug:
         msg:
-          - "Time synchronization: Configured and accurate"
+          - "Time synchronization: Status queried via chronyc tracking"
           - "Configuration files: Created with proper permissions"
           - "Logging setup: {{ 'Configured' if chrony_log_enable else 'Disabled' }}"
           - "Log rotation: {{ 'Configured' if chrony_configure_logrotate else 'Disabled' }}"


### PR DESCRIPTION
## 1. ✨ What this PR does
**Repository configuration**
- Normalizes comment spacing in `release.yml` (prerequisite for the yamllint change).
- Replaces `.yamllint` with the canonical configuration: drops the loosened `comments` rule,
  duplicated `braces`/`brackets` rules, and the `ignore:` block that excluded
  `.github/workflows/**` and `molecule/**` from linting.
- Aligns `.ansible-lint` key order and raises the profile to `production`.
- Adds `tmp/` to `.gitignore`.
- Makes the `pull_request` trigger mapping explicit in `ci.yml`.

**Molecule verification hardening**
- Replaces five mutating tasks in `molecule/default/verify.yml` with read-only queries
  (`stat` / `command` with `changed_when: false`) plus explicit assertions.
- Fixes systemd sandboxing override syntax in `molecule/default/prepare.yml`.
- Unsets `NOTIFY_SOCKET` in the container override.

## 2. 🔍 Why
- Workflow and molecule files were silently excluded from YAML linting.
- `ansible-lint` already reported that the role passes the stricter `production` profile;
  raising the configured profile turns that into an enforced contract.
- The verification playbook drove the system into the expected state instead of checking it.
  A real regression found earlier (the role not ensuring the service was running) was NOT
  caught by `molecule verify`. Standard: development-workflow.md — Writing Molecule Verification Tests.
- The hardened verification immediately surfaced a pre-existing test-harness defect on
  ubuntu2604: empty assignments reset only LIST-type systemd directives, so `ProtectSystem=`
  was rejected as invalid and the vendor value stayed active. Combined with the cleared
  `LogsDirectory=`, `/var/log` stayed read-only and chronyd crashed on startup — while the
  old verification still reported green.

## 3. 💡 Value
- Full YAML coverage — no directory silently exempt from linting.
- The Molecule suite can now actually fail on service, package and permission regressions.
- Verification is idempotent (`changed=0`).

## 4. ✅ Local Verification
- `yamllint .` — exit 0, 2 pre-existing `truthy` warnings on the `on:` key
  (identical in reference roles; changing `on:` would break GitHub Actions)
- `ansible-lint` — 0 failure(s), 0 warning(s), profile `production`
- `molecule test -s default` — passed on `ubuntu2604`, `rockylinux9`, `debian12`
- `systemctl show chrony --property=ProtectSystem` → `no`; no `failed to parse` in journal
- Regression-detection proof (verification FAILS when the service is stopped):
```
TASK [Verify | Assert chrony service is active] ********************************
fatal: [instance]: FAILED! => {
    "assertion": "__verify_service_active.stdout | trim == 'active'",
    "changed": false,
    "evaluated_to": false,
    "msg": "Chrony service is not active (reported: inactive)"
}
```
