### PR TITLE
ci: track reusable workflows on main branch instead of pinned tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   # ================================================================
   ci:
     needs: [branch-name-lint, pr-title-lint]
-    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-ci.yml@v3.0.1
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-ci.yml@main
     with:
       molecule-distros: '["ubuntu2604", "ubuntu2404", "ubuntu2204", "debian13", "debian12", "debian11", "rockylinux9"]'
       molecule-scenarios: '["default", "logging"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,6 @@ jobs:
     name: "Publish to Galaxy"
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
-    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-publish.yml@v3.0.1
+    uses: grzegorzfranus/github-workflows/.github/workflows/ansible-publish.yml@main
     secrets:
       galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -410,9 +410,9 @@ All tags (except `always`) are prefixed with `chrony_` to avoid collisions. Use 
 
 ## CI/CD Pipeline
 
-This repository uses centralized, reusable GitHub Actions workflows from [grzegorzfranus/github-workflows](https://github.com/grzegorzfranus/github-workflows) (`v3.0.1`) for quality assurance, security scanning, and release automation.
+This repository uses centralized, reusable GitHub Actions workflows from [grzegorzfranus/github-workflows](https://github.com/grzegorzfranus/github-workflows) (`@main`) for quality assurance, security scanning, and release automation.
 
-### CI Pipeline (`ansible-ci.yml@v3.0.1`)
+### CI Pipeline (`ansible-ci.yml@main`)
 
 Runs on every Pull Request in a two-tier gate pattern:
 
@@ -425,14 +425,14 @@ Runs on every Pull Request in a two-tier gate pattern:
 7. **Molecule Integration Tests** — executes Molecule test matrix across Ubuntu 26.04, Ubuntu 24.04, Ubuntu 22.04, Debian 13, Debian 12, Debian 11, and Rocky Linux 9 (`ansible-molecule.yml`)
 8. **Merge Check Gate** — single authoritative status check aggregating all results for branch protection
 
-### Release & Publish Pipeline (`ansible-publish.yml@v3.0.1`)
+### Release & Publish Pipeline (`ansible-publish.yml@main`)
 
 Automated via [Release Please](https://github.com/googleapis/release-please):
 
 1. **Push to `main`** → Release Please creates or updates a Release PR with automated changelog generation
 2. **Release PR Validation** → validates YAML syntax and actions schema before setting `Merge Check` status
 3. **Merge Release PR** → creates Git version tag and GitHub Release automatically
-4. **Ansible Galaxy Publish** → publishes tagged release to Ansible Galaxy via `ansible-publish.yml@v3.0.1` with exponential backoff retry logic
+4. **Ansible Galaxy Publish** → publishes tagged release to Ansible Galaxy via `ansible-publish.yml@main` with exponential backoff retry logic
 
 ## Example Playbooks
 


### PR DESCRIPTION
Closes #56

## 1. ✨ What this PR does
- Updates first-party reusable workflow references in `.github/workflows/ci.yml` and `.github/workflows/release.yml` from `@v3.0.1` tag to `@main` branch.
- Updates reusable workflow version references in `README.md` (CI/CD Pipeline section).
- Preserves 40-character commit SHA pinning for third-party actions (`actions/checkout`, `googleapis/release-please-action`, `raven-actions/actionlint`).

## 2. 🔍 Why
- The `grzegorzfranus/github-workflows` repository does not maintain a `latest` tag (highest tag is `v3.1.2`), so `@latest` is not a valid git ref.
- Referencing `@main` ensures caller workflows automatically consume the latest first-party reusable workflow updates.
- Complies with security policy in `github-workflows/references/security.md`, which permits branch references for first-party reusable workflows owned by the same user (`grzegorzfranus`).

## 3. 💡 Value
- Eliminates manual version bumps for first-party reusable workflows across role repositories.
- Guarantees immediate consumption of centralized CI/CD updates and hardening.

## 4. ✅ Local Verification
- `actionlint` (Passed with 0 errors)
- `yamllint .` (Passed with 0 errors)
