### PR TITLE
docs: update remaining reusable workflow version reference to @main

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ ansible-lint
 molecule test --all
 ```
 
-Centralized workflows from [github-workflows](https://github.com/grzegorzfranus/github-workflows) version `v3.0.1` run these checks automatically on PR creation.
+Centralized workflows from [github-workflows](https://github.com/grzegorzfranus/github-workflows) (branch `@main`) run these checks automatically on PR creation.
 
 ## 📝 License
 


### PR DESCRIPTION
Closes #59

## 1. ✨ What this PR does
- Updates remaining reusable workflow version reference in `README.md` from `v3.0.1` to `@main` branch.

## 2. 🔍 Why
- Harmonizes documentation with PR #57 which updated workflow execution targets to `@main`.
