### PR TITLE
feat(logrotate): make dateformat configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ chrony_maxdistance: 3.0
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `chrony_logrotate_options` | Dictionary of logrotate settings (`archive_directory_path`, `frequency`, `count`, `missingok`, `compress`, `nocreate`, `copytruncate`, `dateext`) | *See defaults/main.yml* |
+| `chrony_logrotate_options` | Dictionary of logrotate settings (`archive_directory_path`, `frequency`, `count`, `missingok`, `compress`, `nocreate`, `copytruncate`, `dateext`, `dateformat`) | *See defaults/main.yml* |
 
 ### Real-Time Clock (RTC) Settings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,7 +177,7 @@ chrony_logchange: "0.5"
 
 # Logrotate configuration options for managing chrony log retention
 # Valid values: dictionary with keys archive_directory_path (str), frequency (enum),
-#   count (int > 0), missingok (bool), compress (bool), nocreate (bool), copytruncate (bool), dateext (bool)
+#   count (int > 0), missingok (bool), compress (bool), nocreate (bool), copytruncate (bool), dateext (bool), dateformat (str)
 chrony_logrotate_options:
   archive_directory_path: "/var/log/chrony/archive"
   frequency: "daily"
@@ -187,6 +187,7 @@ chrony_logrotate_options:
   nocreate: true
   copytruncate: false
   dateext: true
+  dateformat: ".%Y-%m-%d"
 
 # -----------------------------------------------------------------------------
 # 7. Real Time Clock (RTC) Settings

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -221,6 +221,10 @@ argument_specs:
             description: Add date extension to rotated logs.
             type: bool
             default: true
+          dateformat:
+            description: Date suffix appended to rotated log filenames when dateext is enabled.
+            type: str
+            default: ".%Y-%m-%d"
       chrony_rtc_settings:
         description: Real-Time Clock configuration dictionary.
         type: dict

--- a/molecule/logging/converge.yml
+++ b/molecule/logging/converge.yml
@@ -34,4 +34,5 @@
           nocreate: false
           copytruncate: true
           dateext: true
+          dateformat: "-%Y%m%d"
           archive_directory_path: "/var/log/chrony-test/archive"

--- a/molecule/logging/verify.yml
+++ b/molecule/logging/verify.yml
@@ -43,6 +43,20 @@
           - __verify_logrotate_file.stat.gr_name == 'root'
           - __verify_logrotate_file.stat.mode == '0644'
 
+    - name: Verify | Slurp rendered logrotate configuration
+      become: true
+      ansible.builtin.slurp:
+        src: "/etc/logrotate.d/chrony"
+      register: __verify_logrotate_slurp
+
+    - name: Verify | Assert rendered dateformat directive
+      ansible.builtin.assert:
+        that:
+          - "'dateext' in (__verify_logrotate_slurp.content | b64decode)"
+          - "'dateformat -%Y%m%d' in (__verify_logrotate_slurp.content | b64decode)"
+        fail_msg: "Rendered logrotate configuration does not contain the expected dateformat directive"
+        success_msg: "Rendered logrotate configuration contains the expected dateformat directive"
+
     - name: Verify | Validate logrotate dry-run execution
       ansible.builtin.command:
         cmd: "logrotate -d /etc/logrotate.d/chrony"

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -309,7 +309,10 @@
       - chrony_logrotate_options.nocreate is boolean
       - chrony_logrotate_options.copytruncate is boolean
       - chrony_logrotate_options.dateext is boolean
-    fail_msg: "Invalid chrony_logrotate_options"
+      - chrony_logrotate_options.dateformat is not defined or
+        (chrony_logrotate_options.dateformat is string and
+         chrony_logrotate_options.dateformat | length > 0)
+    fail_msg: "Invalid chrony_logrotate_options (dateformat must be a non-empty string when provided)"
     success_msg: "Remaining logrotate options are valid"
   when: chrony_configure_logrotate | default(false) | bool
 

--- a/templates/logrotate/chrony.j2
+++ b/templates/logrotate/chrony.j2
@@ -20,7 +20,7 @@
     {% endif %}
     {% if chrony_logrotate_options.dateext | bool %}
     dateext
-    dateformat .%Y-%m-%d
+    dateformat {{ chrony_logrotate_options.dateformat | default('.%Y-%m-%d') }}
     {% endif %}
     {% if chrony_logrotate_options.archive_directory_path is defined and chrony_logrotate_options.archive_directory_path | length > 0 %}
     olddir {{ chrony_logrotate_options.archive_directory_path }}


### PR DESCRIPTION
Closes #62

## 1. ✨ What this PR does

This PR exposes the `dateformat` logrotate option for Chrony rotated logs:
- Adds `dateformat: ".%Y-%m-%d"` to `chrony_logrotate_options` in `defaults/main.yml`.
- Updates `templates/logrotate/chrony.j2` to use `{{ chrony_logrotate_options.dateformat | default('.%Y-%m-%d') }}` when `dateext` is enabled.
- Adds non-empty string validation to `tasks/assert.yml` validating the key only when provided.
- Updates `meta/argument_specs.yml` and `README.md` to document the new `dateformat` option.
- Adds test assertions to Molecule `logging` scenario (`converge.yml` & `verify.yml`).

### Changed Files
- `README.md`
- `defaults/main.yml`
- `meta/argument_specs.yml`
- `molecule/logging/converge.yml`
- `molecule/logging/verify.yml`
- `tasks/assert.yml`
- `templates/logrotate/chrony.j2`

### Rendered Configuration Comparison

**Before (or with default `dateformat: ".%Y-%m-%d"` / omitted key):**
```text
/var/log/chrony/*.log {
    daily
    rotate 30
    missingok
    compress
    nocreate
    dateext
    dateformat .%Y-%m-%d
    olddir /var/log/archive/chrony
    sharedscripts
    postrotate
        /usr/bin/chronyc cyclelogs >/dev/null 2>&1 || true
    endscript
}
```

**After (with custom `dateformat: "-%Y%m%d"`):**
```text
/var/log/chrony/*.log {
    daily
    rotate 30
    missingok
    compress
    nocreate
    dateext
    dateformat -%Y%m%d
    olddir /var/log/archive/chrony
    sharedscripts
    postrotate
        /usr/bin/chronyc cyclelogs >/dev/null 2>&1 || true
    endscript
}
```

## 2. 🔍 Why

The logrotate configuration template previously hardcoded `dateformat .%Y-%m-%d`. Fleet standards and log archiving scripts require standard suffixes such as `-%Y%m%d`. Making `dateformat` configurable allows aligning Chrony log rotation archives with fleet-wide patterns.

### Backward Compatibility
Backward compatibility is strictly preserved across both rendering and validation paths:
- The template filter `default('.%Y-%m-%d')` ensures that existing inventories supplying `chrony_logrotate_options` without `dateformat` render the exact historical configuration.
- The assertion validates the value only when the key is provided, because role argument spec suboption defaults are not injected into the variable, therefore requiring the key would break every existing consumer that supplies the dictionary without it.

## 3. 💡 Value

- Allows uniform log archiving across systems without hardcoded suffix mismatches.
- Fully backward-compatible: no disruption to existing deployments and consumers.

## 4. ✅ Local Verification

- `yamllint .` (Passed)
- `ansible-lint` (Passed, 0 failures, 0 warnings)
- `molecule test -s default` (Passed, 8/8 actions successful)
- `molecule test -s logging` (Passed, verified rendered `dateformat -%Y%m%d` directive and dry-run)
- Standalone regression playbook verifying backward compatibility without `dateformat` key (failed=0) and assertion rejection on empty string `dateformat: ""` (failed=1).
